### PR TITLE
fix: convert height from cm to m

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 function calculateBMI(height, weight) {
+    height = height / 100; // Convert height from cm to meters
     return weight / (height * height);
   }
   


### PR DESCRIPTION
Convert height from cm to m, in order to fix the calculation for bmi.